### PR TITLE
Create a 6-node cluster with different roles (3 default + 3 foo)

### DIFF
--- a/01-shopping-cart-service-scala/README.md
+++ b/01-shopping-cart-service-scala/README.md
@@ -20,6 +20,7 @@ kubectl config use-context minikube
 ```
 kubectl apply -f deployment/rbac.yml
 kubectl apply -f deployment/deployment.yml
+kubectl apply -f deployment/deployment-with-roles.yml
 kubectl apply -f deployment/service.yml
 ```
 

--- a/01-shopping-cart-service-scala/deployment/deployment-with-roles.yml
+++ b/01-shopping-cart-service-scala/deployment/deployment-with-roles.yml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cartapp
+  name: cartapp-roles-foo
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: cartapp
+  template:
+    metadata:
+      labels:
+        app: cartapp
+    spec:
+      containers:
+      - name: cartapp
+        image: ignasi35/shopping-cart-service-scala:latest
+        env:
+            - name: JAVA_OPTS
+              value: "-Dconfig.resource=kubernetes.conf -Dakka.cluster.roles.0=foo"
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: management
+        livenessProbe:
+          httpGet:
+            path: /alive
+            port: management
+        ports:
+        - name: management
+          containerPort: 9101
+          protocol: TCP
+        - name: http
+          containerPort: 8101
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 0.5
+            memory: 1024Mi
+          requests:
+            cpu: 0.5
+            memory: 1024Mi

--- a/01-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServer.scala
+++ b/01-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServer.scala
@@ -21,9 +21,9 @@ object ShoppingCartServer {
 
     val service: HttpRequest => Future[HttpResponse] =
       ServiceHandler.concatOrNotFound(
-        proto.ShoppingCartServiceHandler.partial(new ShoppingCartServiceImpl),
+        proto.ShoppingCartServiceHandler.partial(new ShoppingCartServiceImpl(system)),
         // ServerReflection enabled to support grpcurl without import-path and proto parameters
-        ServerReflection.partial(List(proto.ShoppingCartService))) // <1>
+        ServerReflection.partial(List(proto.ShoppingCartService)))
 
     val bound =
       Http().newServerAt(interface, port).bind(service).map(_.addToCoordinatedShutdown(3.seconds)) // <2>

--- a/01-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServiceImpl.scala
+++ b/01-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServiceImpl.scala
@@ -2,15 +2,20 @@ package shopping.cart
 
 import scala.concurrent.Future
 
+import akka.actor.typed.ActorSystem
+import akka.cluster.typed.Cluster
 import org.slf4j.LoggerFactory
 
-class ShoppingCartServiceImpl extends proto.ShoppingCartService {
+class ShoppingCartServiceImpl(system: ActorSystem[_]) extends proto.ShoppingCartService {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  override def addItem(in: proto.AddItemRequest): Future[proto.Cart] = { // <1>
+  private val cluster = Cluster.get(system)
+
+  override def addItem(in: proto.AddItemRequest): Future[proto.Cart] = {
     logger.info("addItem {} to cart {}", in.itemId, in.cartId)
-    Future.successful(proto.Cart(items = List(proto.Item(in.itemId, in.quantity))))
+    val msg = s"${in.itemId} - in node with roles [${cluster.selfMember.roles.mkString(", ")}]"
+    Future.successful(proto.Cart(items = List(proto.Item(msg, in.quantity))))
   }
 
 }


### PR DESCRIPTION
This PR introduces the idea to create multiple `Deployment` where only a few settings change. The name of each `Deployment` is different but selectors are the same so Akka Cluster Bootstrap will connect pods from different `ReplicaSet`s  into the same cluster.

Each `Deployment` will set different roles.