### PR TITLE
Braindump of the default values and user YAML for an Akka CRD

### DIFF
--- a/01-shopping-cart-service-scala/.vscode/settings.json
+++ b/01-shopping-cart-service-scala/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}

--- a/01-shopping-cart-service-scala/deployment/Akka-CRD-defaults.yml
+++ b/01-shopping-cart-service-scala/deployment/Akka-CRD-defaults.yml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: AkkaCluster
+metadata:
+  labels:
+    app: todo
+  name: todo
+  namespace: default
+spec:
+## The replicas value is no longer in the spec root and, instead, 
+## a new field `nodesets` (below) is introduced.
+##  replicas: 3
+  selector:
+    matchLabels:
+      app: todo
+  template:
+    metadata:
+      labels:
+        app: todo
+    spec:
+      containers:
+      - name: todo
+        image: no-registry/no-image:latest
+        env:
+            ## We should recommend injecting ports as ENV_VARS (instead of keeping values in sync)
+            ## with that recommendation users wouldn't even need to add all these ENV_VARS or the 
+            ## ports below since those would be default values of the spec.
+            - name: PORT_HTTP
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.template.spec.containers[...]...
+            - name: PORT_HTTPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.template.spec.containers[...]...
+            - name: PORT_MANAGEMENT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.template.spec.containers[...]...
+            - name: PORT_AKKA_REMOTE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.template.spec.containers[...]...
+        ## Health checks would be default values. Nothing to add by 
+        ## the user if they use default Akka Management.
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: management
+        livenessProbe:
+          httpGet:
+            path: /alive
+            port: management
+        ports:
+        - name: remote
+          containerPort: 2552
+          protocol: TCP
+        - name: management
+          containerPort: 9101
+          protocol: TCP
+        - name: http
+          containerPort: 8101
+          protocol: TCP
+        - name: https
+          containerPort: 8143
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 0.5
+            memory: 1024Mi
+          requests:
+            cpu: 0.5
+            memory: 1024Mi
+  ## Each `nodeset` must have a name and a number of replicas. Then, the spec of the 
+  ## nodeset follows the spec of a Deployment and it'll be overlaid on top of the 
+  ## spec.template above.
+  nodesets:
+    - name: default
+      replicas: 3
+      spec:
+        containers:
+        - env:
+            - name: JAVA_OPTS
+              value: "-Dconfig.resource=kubernetes.conf"
+    - name: projections
+      replicas: 3
+      metadata:
+        labels:
+          roles: projections
+      spec:
+        containers:
+        - env:
+          - name: JAVA_OPTS
+            value: "-Dconfig.resource=kubernetes.conf -Dakka.cluster.roles.0=projections"

--- a/01-shopping-cart-service-scala/deployment/Akka-CRD-usercode.yml
+++ b/01-shopping-cart-service-scala/deployment/Akka-CRD-usercode.yml
@@ -9,10 +9,10 @@ spec:
 ## The replicas value is no longer in the spec root and, instead, 
 ## a new field `nodesets` (below) is introduced.
 ##  replicas: 3
-  selector:
+  selector: ### This is use by the replicaset to locate and count the running pods
     matchLabels:
       app: cartapp
-  template:
+  template: ### used to create new pods.
     metadata:
       labels:
         app: cartapp

--- a/01-shopping-cart-service-scala/deployment/Akka-CRD-usercode.yml
+++ b/01-shopping-cart-service-scala/deployment/Akka-CRD-usercode.yml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: AkkaCluster
+metadata:
+  labels:
+    app: cartapp
+  name: cartapp
+  namespace: my-namespace
+spec:
+## The replicas value is no longer in the spec root and, instead, 
+## a new field `nodesets` (below) is introduced.
+##  replicas: 3
+  selector:
+    matchLabels:
+      app: cartapp
+  template:
+    metadata:
+      labels:
+        app: cartapp
+    spec:
+      containers:
+      - name: cartapp
+        image: ignasi35/shopping-cart-service-scala:latest
+  ## Each `nodeset` must have a name and a number of replicas. Then, the spec of the 
+  ## nodeset follows the spec of a Deployment and it'll be overlaid on top of the 
+  ## spec.template above.
+  nodesets:
+    - name: cartapp-node
+      replicas: 3
+      spec:
+        containers:
+        - env:
+            - name: JAVA_OPTS
+              value: "-Dconfig.resource=kubernetes.conf"
+    - name: cartapp-projections-node
+      replicas: 3
+      metadata:
+        labels:
+          roles: projections
+      spec:
+        containers:
+        - env:
+          - name: JAVA_OPTS
+            value: "-Dconfig.resource=kubernetes.conf -Dakka.cluster.roles.0=projections"


### PR DESCRIPTION
Adds a couple of YAML introducing the structure of an Akka Cluster CRD (early iterations).

One YAML represents the default values of each CR, while the other represents an example of a user trying to deploy an app with 1 cluster of 6 nodes where 3 nodes have a specific role.
